### PR TITLE
Update Prep-VDA.ps1 for VcRedist 2.0

### DIFF
--- a/scripts/Prep-VDA.ps1
+++ b/scripts/Prep-VDA.ps1
@@ -17,41 +17,40 @@ try {
     # Copy XD media locally
     # Write-Host "Copying XD Media locally"
     # cwcOS-Tools\Download-File -FileName $VDA_MediaName -Path $VDA_MediaLocation -ToFolder $VDA_LocalMediaLocation -verbose
-    Start-Transcript -Path C:\cfn\log\Prep-VDA.ps1.txt -Append    
+	Start-Transcript -Path C:\cfn\log\Prep-VDA.ps1.txt -Append    
 	
     Import-Module ServerManager
-    Write-Host "Enabling RDS Server Role"
-    Add-WindowsFeature RDS-RD-Server
+	Write-Host "Enabling RDS Server Role"
+	Add-WindowsFeature RDS-RD-Server
 
-    # Write-Host "Enabling Desktop Experience"
-    # Install-WindowsFeature -Name Desktop-Experience
+	# Write-Host "Enabling Desktop Experience"
+	# Install-WindowsFeature -Name Desktop-Experience
 
-    Write-Host "Enabling Remote Assistance"
-    Install-WindowsFeature -Name Remote-Assistance 
+	Write-Host "Enabling Remote Assistance"
+	Install-WindowsFeature -Name Remote-Assistance 
 
-    ### Install Visual C++ Redistributables
-    Write-Host "Installing Nuget"
-    Install-PackageProvider -Name "NuGet" -MinimumVersion "2.8.5.201" -Force
+	### Install C++ libararies
+	Write-Host "Installing Nuget"
+	Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 	Write-Host "Installing VcRedist Module"
-	#Reference: https://github.com/aaronparker/Install-VisualCRedistributables, https://docs.stealthpuppy.com/docs/vcredist
-	Install-Module -Name "VcRedist" -Force
+	Install-Module -Name VcRedist -Force # Reference: https://github.com/aaronparker/Install-VisualCRedistributables
 	Write-Host "Creating VcRedist Temp Folder"
-	$VcPath = "C:\Temp\VcRedist"
-    New-Item -Path $VcPath -ItemType "Directory"
+    New-Item C:\Temp\VcRedist -ItemType Directory
     Write-Host "Downloading VcRedist Redist to Temp Folder"
-	$VcList = Get-VcList
-	Save-VcRedist -VcList $VcList -Path $VcPath
+	Get-VcList | Get-VcRedist -Path C:\Temp\VcRedist
     Write-Host "Installing VcRedist"
-    $Installed = Install-VcRedist -VcList $VcList -Path $VcPath -Silent
+    $VcList = Get-VcList
+    Install-VcRedist -Path C:\Temp\VcRedist -VcList $VcList
 
-    # Install Pre-req for v7.18 https://docs.citrix.com/en-us/session-recording/current-release/system-requirements.html
-    Write-Host "Downloading Microsoft .NET Framework 4.7.1"
-    cwcOS-Tools\Download-File -FileName "NDP471-KB4033342-x86-x64-AllOS-ENU.exe" -Path "https://download.microsoft.com/download/9/E/6/9E63300C-0941-4B45-A0EC-0008F96DD480" -ToFolder "C:\cfn\scripts\" -verbose
-    Write-Host "Installing Microsoft .NET Framework 4.7.1"
-    #Install-MSIOrEXE -installerPath c:\cfn\scripts\NDP471-KB4033342-x86-x64-AllOS-ENU.exe -installerArgs @("/Q", "/norestart")
+	# Install Pre-req for v7.18 https://docs.citrix.com/en-us/session-recording/current-release/system-requirements.html
+	Write-Host "Downloading Microsoft .NET Framework 4.7.1"
+	cwcOS-Tools\Download-File -FileName "NDP471-KB4033342-x86-x64-AllOS-ENU.exe" -Path "https://download.microsoft.com/download/9/E/6/9E63300C-0941-4B45-A0EC-0008F96DD480" -ToFolder "C:\cfn\scripts\" -verbose
+	Write-Host "Installing Microsoft .NET Framework 4.7.1"
+	#Install-MSIOrEXE -installerPath c:\cfn\scripts\NDP471-KB4033342-x86-x64-AllOS-ENU.exe -installerArgs @("/Q", "/norestart")
     Start-Process -FilePath "c:\cfn\scripts\NDP471-KB4033342-x86-x64-AllOS-ENU.exe" -ArgumentList "/q /norestart" -Wait
+
 
 }
 catch {
-    $_ | Write-AWSQuickStartException
+	$_ | Write-AWSQuickStartException
 }

--- a/scripts/Prep-VDA.ps1
+++ b/scripts/Prep-VDA.ps1
@@ -17,40 +17,41 @@ try {
     # Copy XD media locally
     # Write-Host "Copying XD Media locally"
     # cwcOS-Tools\Download-File -FileName $VDA_MediaName -Path $VDA_MediaLocation -ToFolder $VDA_LocalMediaLocation -verbose
-	Start-Transcript -Path C:\cfn\log\Prep-VDA.ps1.txt -Append    
+    Start-Transcript -Path C:\cfn\log\Prep-VDA.ps1.txt -Append    
 	
     Import-Module ServerManager
-	Write-Host "Enabling RDS Server Role"
-	Add-WindowsFeature RDS-RD-Server
+    Write-Host "Enabling RDS Server Role"
+    Add-WindowsFeature RDS-RD-Server
 
-	# Write-Host "Enabling Desktop Experience"
-	# Install-WindowsFeature -Name Desktop-Experience
+    # Write-Host "Enabling Desktop Experience"
+    # Install-WindowsFeature -Name Desktop-Experience
 
-	Write-Host "Enabling Remote Assistance"
-	Install-WindowsFeature -Name Remote-Assistance 
+    Write-Host "Enabling Remote Assistance"
+    Install-WindowsFeature -Name Remote-Assistance 
 
-	### Install C++ libararies
-	Write-Host "Installing Nuget"
-	Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+    ### Install Visual C++ Redistributables
+    Write-Host "Installing Nuget"
+    Install-PackageProvider -Name "NuGet" -MinimumVersion "2.8.5.201" -Force
 	Write-Host "Installing VcRedist Module"
-	Install-Module -Name VcRedist -Force # Reference: https://github.com/aaronparker/Install-VisualCRedistributables
+	#Reference: https://github.com/aaronparker/Install-VisualCRedistributables, https://docs.stealthpuppy.com/docs/vcredist
+	Install-Module -Name "VcRedist" -Force
 	Write-Host "Creating VcRedist Temp Folder"
-    New-Item C:\Temp\VcRedist -ItemType Directory
+	$VcPath = "C:\Temp\VcRedist"
+    New-Item -Path $VcPath -ItemType "Directory"
     Write-Host "Downloading VcRedist Redist to Temp Folder"
-	Get-VcList | Get-VcRedist -Path C:\Temp\VcRedist
+	$VcList = Get-VcList
+	Save-VcRedist -VcList $VcList -Path $VcPath
     Write-Host "Installing VcRedist"
-    $VcList = Get-VcList
-    Install-VcRedist -Path C:\Temp\VcRedist -VcList $VcList
+    $Installed = Install-VcRedist -VcList $VcList -Path $VcPath -Silent
 
-	# Install Pre-req for v7.18 https://docs.citrix.com/en-us/session-recording/current-release/system-requirements.html
-	Write-Host "Downloading Microsoft .NET Framework 4.7.1"
-	cwcOS-Tools\Download-File -FileName "NDP471-KB4033342-x86-x64-AllOS-ENU.exe" -Path "https://download.microsoft.com/download/9/E/6/9E63300C-0941-4B45-A0EC-0008F96DD480" -ToFolder "C:\cfn\scripts\" -verbose
-	Write-Host "Installing Microsoft .NET Framework 4.7.1"
-	#Install-MSIOrEXE -installerPath c:\cfn\scripts\NDP471-KB4033342-x86-x64-AllOS-ENU.exe -installerArgs @("/Q", "/norestart")
+    # Install Pre-req for v7.18 https://docs.citrix.com/en-us/session-recording/current-release/system-requirements.html
+    Write-Host "Downloading Microsoft .NET Framework 4.7.1"
+    cwcOS-Tools\Download-File -FileName "NDP471-KB4033342-x86-x64-AllOS-ENU.exe" -Path "https://download.microsoft.com/download/9/E/6/9E63300C-0941-4B45-A0EC-0008F96DD480" -ToFolder "C:\cfn\scripts\" -verbose
+    Write-Host "Installing Microsoft .NET Framework 4.7.1"
+    #Install-MSIOrEXE -installerPath c:\cfn\scripts\NDP471-KB4033342-x86-x64-AllOS-ENU.exe -installerArgs @("/Q", "/norestart")
     Start-Process -FilePath "c:\cfn\scripts\NDP471-KB4033342-x86-x64-AllOS-ENU.exe" -ArgumentList "/q /norestart" -Wait
-
 
 }
 catch {
-	$_ | Write-AWSQuickStartException
+    $_ | Write-AWSQuickStartException
 }


### PR DESCRIPTION
# Description

Updated `Prep-VDA.ps1` with:

* Changed `Get-VcRedist` to `Save-VcRedist` - function name change introduced in `VcRedist 2.0`
* Added `-Silent` parameter to `Install-VcRedist` so that silent command lines are used when installing the Visual C++ Redistributables
* Small updated to code logic for the `$VcRedist` variable and `VcRedist` install steps

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
